### PR TITLE
 Error sending the TrafficFlowObserved data model.

### DIFF
--- a/Transportation/TrafficFlowObserved/doc/spec.md
+++ b/Transportation/TrafficFlowObserved/doc/spec.md
@@ -138,7 +138,7 @@ attribute means no lane reversion.
        "dateObservedTo": "2016-12-07T11:15:00",
        "averageHeadwayTime": 0.5,
        "intensity": 197,
-       "capacity": 0.76
+       "capacity": 0.76,
        "averageVehicleSpeed": 52.6,
        "averageVehicleLength": 9.87,
        "reversedLane": false,


### PR DESCRIPTION
Hello, trying to send the example of the TrafficFlowObserved data model to the Context Broker, the Rest client was throwing me an error. in this commit the error is solved.

Error:
 `{

         "error": "ParseError",

         "description": "Errors found in incoming JSON buffer"

}` 

Cause: The comma in the attribute is missing:  `"capacity": 0.76`.
Solution: The comma is added to the end of the attribute.

Greetings.